### PR TITLE
Add support for sign_up and sign_in as API calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email])
+
+    devise_parameter_sanitizer.permit(:sign_in) do |user_params|
+      user_params.permit(:username, :password, :remember_me)
+    end
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email])
 
     devise_parameter_sanitizer.permit(:sign_in) do |user_params|
-      user_params.permit(:username, :password, :remember_me)
+      user_params.permit(:username, :password)
     end
   end
 end

--- a/app/controllers/users/registration_controller.rb
+++ b/app/controllers/users/registration_controller.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+ # POST /resource
+  def create
+    super do |resource|
+      render json: resource.to_json
+      return
+    end
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :email])
+  end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # GET /resource/sign_in
+  def new
+    render status: :unauthorized
+  end
+
+  # POST /resource/sign_in
+  def create
+    super do |user|
+      render json: user.to_json
+      return
+    end
+  end
+
+  def auth
+    if user_signed_in?
+      render json: current_user.to_json
+    else
+      render status: :unauthorized, json: { error: 'Not signed in' }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :users
+	devise_for :users,
+		controllers: { sessions: 'users/sessions', registrations: 'users/registrations' }
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
 	root to: 'root#index'


### PR DESCRIPTION
## What is this?

The following changes add support for making the sign up and sign in routes callable via API in React. Responses return the User object in JSON. The changes block direct routes to the regular devise views forcing the use of React for sign in and sign up pages. Add support for username to sign up fields.

## Trello
https://trello.com/c/5Ej1t7sJ/4-add-devise-to-backend